### PR TITLE
feat: add secondary-light background to <Border />

### DIFF
--- a/src/lib/components/board/_styles.less
+++ b/src/lib/components/board/_styles.less
@@ -307,6 +307,10 @@
 			background: var(--coo-secondary-04);
 		}
 
+		&-secondary-light {
+			background: var(--coo-secondary-02);
+		}
+
 		&-secondary-medium {
 			background: var(--coo-secondary-03);
 		}

--- a/src/lib/components/board/index.tsx
+++ b/src/lib/components/board/index.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
-import { ReactNode, useState } from 'react';
+import { HTMLAttributes, ReactNode, useState } from 'react';
 
-type Props = {
+type Props = HTMLAttributes<HTMLDivElement> & {
   backgroundImage?: string;
   borderType?: 'light' | 'none';
   buttonPosition?: 'vertical' | 'adaptive';
@@ -30,7 +30,7 @@ type Props = {
     | 'unactive'
     | 'disabled'
     | 'in-evidence';
-  type?: 'primary' | 'primary-light' | 'secondary' | 'secondary-medium' | 'error' | 'rounded' | 'add-new';
+  type?: 'primary' | 'primary-light' | 'secondary' | 'secondary-light' | 'secondary-medium' | 'error' | 'rounded' | 'add-new';
   width?: string;
 };
 
@@ -58,6 +58,7 @@ function Board({
   overflow,
   hoverType,
   onClick,
+  ...rest
 }: Props) {
   const [isHover, setIsHover] = useState(false);
 
@@ -111,6 +112,7 @@ function Board({
 
   return (
     <div
+      {...rest}
       style={boardStyle}
       className={`l-board ${presetModifiers} ${modifier} ${cssMode} ${className}`}
       onClick={onClick}


### PR DESCRIPTION

  Summary

  - Add secondary-light value to the Board type prop, mapped to --coo-secondary-02 background
  - Forward arbitrary HTMLDivElement attributes to the root <div> via ...rest

  Test plan

  - Render <Board type="secondary-light" main="..." /> and verify the background uses --coo-secondary-02
  - Pass extra div attributes (e.g. data-testid, aria-*, id) and verify they appear on the root element
  - Confirm explicit props (className, style, onClick, onMouseEnter/Leave) still take precedence over anything
  passed via ...rest
  - Existing type values (primary, primary-light, secondary, secondary-medium, error, rounded, add-new) still
  render correctly
