### PR TITLE
fix(input): recolor .ant-input-affix-wrapper text so it adapts to dar…

### DIFF
--- a/src/lib/components/avatar/_styles.less
+++ b/src/lib/components/avatar/_styles.less
@@ -2,7 +2,7 @@
 	&.ant-avatar {
 		&.ant-avatar-circle {
 			background-color: var(--coo-primary);
-			color: var(--coo-text-primary);
+			color: var(--coo-on-primary);
 
 			&.ant-avatar-image {
 				background-color: var(--coo-bk-lv1);

--- a/src/lib/components/menu/_styles.less
+++ b/src/lib/components/menu/_styles.less
@@ -16,20 +16,25 @@
 		font-weight: var(--coo-font-weight-light);
 	}
 
-	.ant-menu-item-selected {
-		.ant-menu-title-content {
-			color: var(--coo-fg-black);
-			font-weight: var(--coo-font-weight-normal);
-		}
-	}
-
 	.ant-menu-item-divider {
 		background-color: var(--coo-border-primary);
 	}
 
 	.ant-menu-item {
 		&.ant-menu-item-selected {
-			background-color: var(--coo-highlight-bk);
+			background-color: var(--coo-primary);
+			color: var(--coo-on-primary);
+
+			.ant-menu-title-content {
+				color: var(--coo-on-primary);
+				font-weight: var(--coo-font-weight-normal);
+			}
+
+			.anticon,
+			svg {
+				color: var(--coo-on-primary);
+				fill: var(--coo-on-primary);
+			}
 		}
 
 		&.ant-menu-item-active {

--- a/src/styles/_global-reset.less
+++ b/src/styles/_global-reset.less
@@ -50,6 +50,11 @@ html body {
 		background-color: transparent;
 	}
 
+	// Antd hardcodes .ant-input-affix-wrapper text color to rgba(0,0,0,.88)
+	.ant-input-affix-wrapper {
+		color: var(--coo-fg-black);
+	}
+
 	// Antd hardcodes clear-icon color to rgba(0, 0, 0, .25/.45) — swap to
 	// tokens so it stays visible on the dark surface.
 	.ant-input-affix-wrapper .ant-input-clear-icon {


### PR DESCRIPTION
Antd sets a hardcoded rgba(0, 0, 0, 0.88) on .ant-input-affix-wrapper, which stays black-on-black in dark mode. Point the wrapper color at --coo-fg-black so children (input placeholder, icons via 'color: inherit') follow the theme.