### PR TITLE
fix: recolor .ant-input text so textarea content stays readable

### DIFF
--- a/src/styles/_global-reset.less
+++ b/src/styles/_global-reset.less
@@ -50,7 +50,10 @@ html body {
 		background-color: transparent;
 	}
 
-	// Antd hardcodes .ant-input-affix-wrapper text color to rgba(0,0,0,.88)
+	// Antd hardcodes .ant-input/.ant-input-affix-wrapper text color to
+	// rgba(0,0,0,.88) — swap to a themed token so <input>/<textarea> content
+	// stays readable in dark mode.
+	.ant-input,
 	.ant-input-affix-wrapper {
 		color: var(--coo-fg-black);
 	}


### PR DESCRIPTION
…e in dark

Antd emits :where(.css-XXX).ant-input { color: rgba(0, 0, 0, 0.88) }, which flat-lines to black-on-black for <input>/<textarea> content in dark mode. Extend the existing affix-wrapper override to cover .ant-input itself so the text follows --coo-fg-black.