### PR TITLE
fix: (button) don't overwrite label color on focus for colored variants

### DIFF
--- a/src/styles/_theme.less
+++ b/src/styles/_theme.less
@@ -87,7 +87,9 @@ textarea::placeholder {
 		border-radius: var(--coo-border-radius-small);
 	}
 
-	&:focus {
+	// Focus outline for tonal/outlined buttons — primary button has its own
+	// on-primary label, don't overwrite it here.
+	&:focus:not(.ant-btn-primary):not(.ant-btn-success):not(.ant-btn-error):not(.ant-btn-warning):not(.ant-btn-secondary) {
 		color: rgb(var(--coo-rgb-primary));
 		border-color: rgb(var(--coo-rgb-primary));
 	}


### PR DESCRIPTION
.m-button.ant-btn:focus painted color + border with --coo-primary without checking the variant, so a focused primary button ended up with primary text on primary background — invisible. Scope the focus recolor to variants that are actually outlined/tonal (default / text / ghost / link) via :not() on the colored variants, letting each colored variant keep its own foreground token (like --coo-on-primary on the primary button).