### PR TITLE
fix(styles): use neutral colors for sort headers and pagination controls

### DIFF
--- a/src/lib/components/data-table/_styles.less
+++ b/src/lib/components/data-table/_styles.less
@@ -108,7 +108,7 @@
 
 				.ant-table-column-sorter {
 					vertical-align: 0;
-					color: var(--coo-secondary);
+					color: var(--coo-secondary-01);
 				}
 
 				div {
@@ -120,7 +120,7 @@
 				.ant-table-column-sorter-down {
 					&.on,
 					&.active {
-						color: var(--coo-primary) !important;
+						color: var(--coo-fg-black) !important;
 					}
 				}
 
@@ -132,8 +132,8 @@
 					background: transparent;
 
 					.ant-table-column-sorters {
-						color: var(--coo-primary);
-						font-weight: var(--coo-font-weight-normal);
+						color: var(--coo-fg-black);
+						font-weight: var(--coo-font-weight-bold);
 					}
 				}
 			}

--- a/src/lib/components/pagination/_styles.less
+++ b/src/lib/components/pagination/_styles.less
@@ -6,7 +6,7 @@ html body .ant-pagination {
 		background: transparent;
 
 		a {
-			color: var(--coo-secondary);
+			color: var(--coo-fg-black);
 		}
 
 		&.ant-pagination-item-active,
@@ -23,6 +23,13 @@ html body .ant-pagination {
 	.ant-pagination-prev .ant-pagination-item-link,
 	.ant-pagination-next .ant-pagination-item-link {
 		border-color: var(--coo-secondary-03);
+		color: var(--coo-fg-black);
+	}
+
+	.ant-pagination-prev:hover .ant-pagination-item-link,
+	.ant-pagination-next:hover .ant-pagination-item-link {
+		border-color: var(--coo-primary);
+		color: var(--coo-primary);
 	}
 
 	.ant-pagination-disabled a,


### PR DESCRIPTION
Table sort header now uses fg-black + bold instead of the primary teal, which had poor contrast in light mode. Sort arrows fall back to the gray secondary-01 when inactive. Pagination numbers and prev/next icons switch from magenta secondary to fg-black, keeping primary only for the active/hover state.