### PR TITLE
fix: outlined button type and main-column sticky tabs spacing

### DIFF
--- a/src/lib/components/button/Button.stories.ts
+++ b/src/lib/components/button/Button.stories.ts
@@ -28,7 +28,7 @@ const meta: Meta<typeof Button> = {
 
     type: {
       control: 'select',
-      options: ['default', 'primary', 'primary-outlined', 'ghost', 'dashed', 'text', 'secondary-light', 'secondary', 'success', 'success-light', 'error', 'error-light', 'warning', 'warning-light'],
+      options: ['default', 'primary', 'outlined', 'primary-outlined', 'ghost', 'dashed', 'text', 'secondary-light', 'secondary', 'success', 'success-light', 'error', 'error-light', 'warning', 'warning-light'],
     },
 
     loading: {
@@ -68,6 +68,14 @@ export const PrimaryOutlined: Story = {
     ...commonArgs,
     children: 'Request to Publish',
     type: 'primary-outlined',
+  },
+};
+
+export const Outlined: Story = {
+  args: {
+    ...commonArgs,
+    children: 'Tags',
+    type: 'outlined',
   },
 };
 

--- a/src/lib/components/button/_styles.less
+++ b/src/lib/components/button/_styles.less
@@ -328,6 +328,30 @@
 	}
 
 
+	// Outlined: type='outlined' non genera classi antd → uso m-button--outlined (vedi index.tsx).
+	// Replica l'estetica della Select: bordo trasparente a riposo, primary su hover/focus.
+	&.m-button--outlined {
+		color: var(--coo-fg-black);
+		border-color: transparent;
+		background-color: var(--coo-bk-lv1);
+
+		&:not(:disabled):not(.ant-btn-disabled):hover {
+			color: var(--coo-fg-black);
+			border-color: var(--coo-primary);
+			background-color: var(--coo-bk-lv1);
+		}
+
+		&:not(:disabled):not(.ant-btn-disabled):active,
+		&:not(:disabled):focus,
+		&:not(:disabled):focus-visible {
+			color: var(--coo-fg-black);
+			border-color: var(--coo-primary);
+			background-color: var(--coo-bk-lv1);
+			box-shadow: 0 0 0 2px rgba(var(--coo-rgb-secondary-01), .15);
+		}
+	}
+
+
 	// Disabled: ogni tipo mantiene i suoi colori normali, renderizzato al 30% di opacità
 	&[disabled],
 	&[disabled]:hover {

--- a/src/lib/components/button/_styles.less
+++ b/src/lib/components/button/_styles.less
@@ -327,9 +327,6 @@
 		}
 	}
 
-
-	// Outlined: type='outlined' non genera classi antd → uso m-button--outlined (vedi index.tsx).
-	// Replica l'estetica della Select: bordo trasparente a riposo, primary su hover/focus.
 	&.m-button--outlined {
 		color: var(--coo-fg-black);
 		border-color: transparent;

--- a/src/lib/components/button/index.tsx
+++ b/src/lib/components/button/index.tsx
@@ -8,6 +8,7 @@ export interface Props extends Omit<ButtonProps, 'type' | 'prefix'> {
   type?:
     | ButtonProps['type']
     | 'ghost'
+    | 'outlined'
     | 'primary-outlined'
     | 'secondary-light'
     | 'secondary'
@@ -43,6 +44,7 @@ const Button = forwardRef((props: Props, ref: Ref<HTMLButtonElement | HTMLAnchor
     'm-button--filled': filled,
     'm-button--not-clickable': !onClick && !href,
     'm-button--ghost': type === 'ghost',
+    'm-button--outlined': type === 'outlined',
   });
 
   return (

--- a/src/lib/components/layout/main-column/_styles.less
+++ b/src/lib/components/layout/main-column/_styles.less
@@ -20,7 +20,8 @@
 
 	.ant-layout-content {
 		transition: all .2s;
-		margin-top: @rdb-header-height;
+		// +1.5rem it was padding-top: moved here to fix scroll on tabs sticky
+		margin-top: ~"calc(@{rdb-header-height} + 1.5rem)";
 		height: ~"calc(100vh - @{rdb-header-height})";
 		overflow: auto;
 		margin-left: 0;
@@ -30,7 +31,8 @@
 		display: flex;
 		flex-direction: column;
 		gap: 1.5rem;
-		padding: 1.5rem;
+		padding: 0 1.5rem;
+		padding-bottom: 3.5rem;
 
 		&--no-header {
 			margin-top: 0;


### PR DESCRIPTION
Add a new `outlined` button type replicating the Select appearance: transparent border at rest on --coo-bk-lv1, --coo-primary on hover/focus. Follows the existing `ghost` pattern, since 'outlined' is not a valid antd type and generates no antd class.

Move main-column vertical padding into margin-top and add a bottom padding to fix scrolling with sticky tabs.